### PR TITLE
Rename all "Slayer" mentions to "Combat"

### DIFF
--- a/src/pages/config.html
+++ b/src/pages/config.html
@@ -53,7 +53,7 @@
         </div>
         <select id="bot_type" class="select select-bordered w-full max-w-sm">
             <option>Auction</option>
-            <option>Slayer</option>
+            <option>Combat</option>
         </select>
         <p class="py-6">Configuration documentation is available <a href class="link link-primary" id="documentation">here</a>! Please refer to this prior to contacting support on Discord!</p>
         <p id="savelocation"></p>

--- a/src/pages/launch_menu.html
+++ b/src/pages/launch_menu.html
@@ -55,7 +55,7 @@
         </div>
         <select id="bot_type" class="select select-bordered w-full max-w-sm">
             <option>Auction</option>
-            <option>Slayer</option>
+            <option>Combar</option>
         </select>
         <label class="form-control w-full max-w-sm">
             <div class="label">

--- a/src/utils/releaseChecker.js
+++ b/src/utils/releaseChecker.js
@@ -24,7 +24,7 @@ const releaseNameMap = {
         linux: 'binmaster-auction-linux.zip',
         darwin: 'binmaster-auction-macos.zip',
     },
-    slayer: {
+    combat: {
         win32: 'binmaster-slayer-win.exe.zip',
         linux: 'binmaster-slayer-linux.zip',
         darwin: 'binmaster-slayer-macos.zip',


### PR DESCRIPTION
Recently we renamed the Slayer Macro to Combat Macro, this renames the launcher too. (I don't think people are going to reinstall the whole launcher but we could just have it in the source code, feel free to close)